### PR TITLE
Add SpaCy model dependency.

### DIFF
--- a/presidio-analyzer/Pipfile
+++ b/presidio-analyzer/Pipfile
@@ -5,12 +5,14 @@ name = "pypi"
 
 [packages]
 spacy = ">=3.4.4,<4.0.0"
+en-core-web-lg = {file = "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.6.0/en_core_web_lg-3.6.0-py3-none-any.whl"}
 regex = "*"
 tldextract = "*"
 flask = ">=1.1"
 pyyaml = "*"
 phonenumbers = ">=8.12,<9.0.0"
 typing-extensions = "*"
+gunicorn = "*"
 
 [dev-packages]
 pytest = "*"

--- a/presidio-analyzer/Pipfile.lock
+++ b/presidio-analyzer/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4f632b33235a9cb4179508078a8d9ee031a643cdf7145f582132a81b409de23f"
+            "sha256": "87e2a5ee61e74670c248e5974badfd3dcdaf8225ba0669bcb9690f1bb7e12967"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -209,6 +209,9 @@
             ],
             "version": "==2.0.7"
         },
+        "en-core-web-lg": {
+            "file": "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.6.0/en_core_web_lg-3.6.0-py3-none-any.whl"
+        },
         "filelock": {
             "hashes": [
                 "sha256:0ecc1dd2ec4672a10c8550a8182f1bd0c0a5088470ecd5a125e45f49472fac3d",
@@ -225,6 +228,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==2.3.3"
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0",
+                "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.5'",
+            "version": "==21.2.0"
         },
         "idna": {
             "hashes": [


### PR DESCRIPTION
## Change Description

When running without a Docker container, the SpaCy model doesn't get installed automatically. This PR adds the model to the Pipfile (using `pipenv install $(spacy info en_core_web_lg --url)`) to ensure it gets installed.
